### PR TITLE
Add sanitisation of expression

### DIFF
--- a/lib/calc.coffee
+++ b/lib/calc.coffee
@@ -71,6 +71,10 @@ module.exports = Calc =
 	count: null
 
 	calculateResult: ( expression ) ->
+
+		# Sanitise expression
+		expression = expression.replace(/[×x]/g,"*").replace(/÷/g,"/")
+
 		# `extendedVariables`
 		if atom.config.get( "calc.extendedVariables" )
 			expression = "


### PR DESCRIPTION
For example to allow the use of `×` or `x` for multiplication, and `÷` for divide.

Signed-off-by: Daniel Bayley daniel.bayley@me.com
